### PR TITLE
added pr-8 to H1 in hero

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -101,7 +101,7 @@ export default function Hero () {
 
           <main className="mt-10 mx-auto max-w-7xl px-4 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-28">
             <div className="sm:text-center lg:text-left">
-              <h1 className="text-4xl tracking-tight font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
+              <h1 className="text-4xl tracking-tight font-extrabold text-gray-900 sm:text-5xl md:text-6xl pr-8">
                 <span className="block xl:inline">Full-Featured ML Platform</span>{' '}
                 <span className="block text-indigo-600 xl:inline">in 30 minutes</span>
               </h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "go.primehub.io",
+  "name": "one.primehub.io",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Fixes small issue in Firefox with 's' in 'minutes' was covered by svg.  Tested in Firefox and Chrome.